### PR TITLE
replace obsolete wxStringList with wxArrayString to fix compliation on

### DIFF
--- a/src/FTportSelectionDialog.cpp
+++ b/src/FTportSelectionDialog.cpp
@@ -139,7 +139,7 @@ std::vector<wxString> FTportSelectionDialog::getSelectedPorts()
 	std::vector<wxString> pnames;
 
 	for (int i=0; i < n; i++) {
-		pnames.push_back(wxString(_selectedPorts.Item(i)->GetData()));
+		pnames.push_back(wxString(_selectedPorts.Item(i).GetData()));
 	}
 
 	return pnames;

--- a/src/FTportSelectionDialog.hpp
+++ b/src/FTportSelectionDialog.hpp
@@ -58,7 +58,7 @@ class FTportSelectionDialog
 
     wxListBox * _listBox;
     
-    wxStringList _selectedPorts;
+    wxArrayString _selectedPorts;
 
   private:
 	// any class wishing to process wxWindows events must use this macro


### PR DESCRIPTION
wx-3.1 (openSUSE Tumbleweed current)

Hi ycollet, thanks for your work on keeping Jesse's wonderful toy alive. I've stumbled on another roadblock that I was able to fix, maybe you can use it? I don't know anything about wxwidgets, so the fix might be wrong, but it does compile and I was able to use freqtweak for several hours without problems.